### PR TITLE
Remove redundant clause regarding operator spaces

### DIFF
--- a/pyguide.md
+++ b/pyguide.md
@@ -1376,8 +1376,7 @@ No:  dict ['key'] = list [index]
 Surround binary operators with a single space on either side for assignment
 (`=`), comparisons (`==, <, >, !=, <>, <=, >=, in, not in, is, is not`), and
 Booleans (`and, or, not`). Use your better judgment for the insertion of spaces
-around arithmetic operators but always be consistent about whitespace on either
-side of a binary operator.
+around arithmetic operators (`+`, `-`, `*`, `\`,  `%`, `**`).
 
 ```python {.good}
 Yes: x == 1


### PR DESCRIPTION
This clause is redundant with the first sentence in this paragraph, and makes this sentence confusing.  A hasty reader might mistake the "always be consistent" as a statement about arithmetic operators within a particular project/file.  The true intent of the clause appears to be in differentiating arithmetic operators from binary ones; but I believe that can be done more explicitly and clearly by simply listing them, as is done for the binary operators.  Further, there is no actual need to restate that consistency is necessary for binary operators since the first sentence of the paragraph puts it in black and white, and the following example shows clearly that there is no grey area.